### PR TITLE
Separate data commit changes from tooling ones in refresh-data.sh

### DIFF
--- a/refresh-data.sh
+++ b/refresh-data.sh
@@ -37,54 +37,80 @@ if [ "$BRANCH" ]; then
   git checkout --no-track -B "$BRANCH" origin/master
 fi
 
-bundle update
-if [ "$(git status Gemfile.lock --porcelain)" ]; then
-  git commit Gemfile.lock -m 'Update Gemfile.lock to most recent commons-builder'
-fi
+HAS_BUNDLE_UPDATED=0
 
-if ! jq -e '.hand_maintained_files | contains(["executive/index.json"])' < config.json 2>&1 > /dev/null
-then
-  bundle exec generate_executive_index > executive/index-warnings.txt
-  git add executive/index-warnings.txt executive/index-query-used.rq
-  if [ "$(git status executive/index* --porcelain)" ]; then
-    git commit -a -m "Refresh executive index from Wikidata"
+while true; do
+  if [ "$HAS_BUNDLE_UPDATED" = "0" ]; then
+    # Make sure the right versions of dependencies are installed for this
+    # repository
+    bundle install
+    PRE_POST_UPDATE=""
+  else
+    PRE_POST_UPDATE=" (post-\`bundle update\`)"
   fi
-fi
 
-if ! jq -e '.hand_maintained_files | contains(["legislative/index.json"])' < config.json 2>&1 > /dev/null
-then
-  bundle exec generate_legislative_index > legislative/index-warnings.txt
-  git add legislative/index-warnings.txt legislative/index-query-used.rq legislative/index-terms-query-used.rq
-  if [ "$(git status legislative/index* --porcelain)" ]; then
-    git commit -a -m "Refresh legislative index from Wikidata"
+  if ! jq -e '.hand_maintained_files | contains(["executive/index.json"])' < config.json 2>&1 > /dev/null
+  then
+    bundle exec generate_executive_index > executive/index-warnings.txt
+    git add executive/index-warnings.txt executive/index-query-used.rq
+    if [ "$(git status executive/index* --porcelain)" ]; then
+      git commit -a -m "Refresh executive index from Wikidata$PRE_POST_UPDATE"
+    fi
   fi
-fi
-
-../boundary-data-merge.py
-if [ "$(git status $BOUNDARIES --porcelain)" ]; then
-  git commit -a -m "Update Wikidata IDs for merged items in boundary data"
-fi
-
-rm -f {legislative,executive}/*/*/{query-results.json,query-used.rq}
-bundle exec build update
-git add legislative/* executive/* $BOUNDARIES/position-data-query*
-if [ "$(git status legislative executive --porcelain | grep '^ D')" ]; then
-  git rm $(git status legislative executive --porcelain | grep '^ D' | colrm 1 3)
-fi
-if [ "$(git status legislative executive $BOUNDARIES/position-data-query* --porcelain)" ]; then
-  git commit -a -m "Refresh data from Wikidata"
-fi
-
-rm -f {legislative,executive}/*/*/popolo-m17n.json
-bundle exec build build > build_output.txt
-git add build_output.txt
-git add legislative/* executive/* $BOUNDARIES/position-data.json
-if [ "$(git status legislative executive --porcelain | grep '^ D')" ]; then
-  git rm $(git status legislative executive --porcelain | grep '^ D' | colrm 1 3)
-fi
-if [ "$(git status legislative executive $BOUNDARIES/position-data.json build_output.txt --porcelain)" ]; then
-  git commit -a -m "Rebuild using new Wikidata data"
-fi
+  
+  if ! jq -e '.hand_maintained_files | contains(["legislative/index.json"])' < config.json 2>&1 > /dev/null
+  then
+    bundle exec generate_legislative_index > legislative/index-warnings.txt
+    git add legislative/index-warnings.txt legislative/index-query-used.rq legislative/index-terms-query-used.rq
+    if [ "$(git status legislative/index* --porcelain)" ]; then
+      git commit -a -m "Refresh legislative index from Wikidata$PRE_POST_UPDATE"
+    fi
+  fi
+  
+  # This isn't affected by commons-builder changes, so only needs running the
+  # first time round
+  if [ "$HAS_BUNDLE_UPDATED" = "0" ]; then
+    ../boundary-data-merge.py
+    if  [ "$(git status $BOUNDARIES --porcelain)" ]; then
+      git commit -a -m "Update Wikidata IDs for merged items in boundary data"
+    fi
+  fi
+  
+  rm -f {legislative,executive}/*/*/{query-results.json,query-used.rq}
+  bundle exec build update
+  git add legislative/* executive/*
+  if [ "$(git status legislative executive --porcelain | grep '^ D')" ]; then
+    git rm $(git status legislative executive --porcelain | grep '^ D' | colrm 1 3)
+  fi
+  if [ -e $BOUNDARIES/position-data-query-used.rq ]; then
+    git add $BOUNDARIES/position-data-query-*
+  fi
+  if [ "$(git status --porcelain)" ]; then
+    git commit -a -m "Refresh data from Wikidata$PRE_POST_UPDATE"
+  fi
+  
+  rm -f {legislative,executive}/*/*/popolo-m17n.json
+  bundle exec build build > build_output.txt
+  git add build_output.txt
+  git add legislative/* executive/*
+  if [ "$(git status legislative executive --porcelain | grep '^ D')" ]; then
+    git rm $(git status legislative executive --porcelain | grep '^ D' | colrm 1 3)
+  fi
+  if [ -e $BOUNDARIES/position-data.json ]; then
+    git add $BOUNDARIES/position-data.json
+  fi
+  if [ "$(git status --porcelain)" ]; then
+    git commit -a -m "Rebuild using new Wikidata data$PRE_POST_UPDATE"
+  fi
+  
+  bundle update
+  if [ "$(git status Gemfile.lock --porcelain)" ]; then
+    git commit Gemfile.lock -m 'Update Gemfile.lock to most recent commons-builder'
+    HAS_BUNDLE_UPDATED=1
+  else
+    break
+  fi
+done
 
 if [ "$BRANCH" ]; then
   if git rev-parse --verify $BRANCH@{u} > /dev/null 2>&1; then
@@ -93,3 +119,4 @@ if [ "$BRANCH" ]; then
     git push -u origin $BRANCH
   fi
 fi
+


### PR DESCRIPTION
refresh-data.sh now runs through once using the previous dependency
versions to pull in new upstream data changes, and then runs `bundle
update` to use the most recent version of `commons-builder`. If there
were any changes to dependencies it runs through the build again to make
tooling-related changes.

This effectively separates out upstream data changes from tooling
changes, to make the resulting PRs easier to review.