### PR TITLE
echo something obvious if `bundle exec build build` returns non-zero

### DIFF
--- a/refresh-data.sh
+++ b/refresh-data.sh
@@ -90,7 +90,10 @@ while true; do
   fi
   
   rm -f {legislative,executive}/*/*/popolo-m17n.json
-  bundle exec build build > build_output.txt
+  if ! bundle exec build build > build_output.txt; then
+    echo "Build failed. See build_output.txt"
+    exit 1
+  fi
   git add build_output.txt
   git add legislative/* executive/*
   if [ "$(git status legislative executive --porcelain | grep '^ D')" ]; then


### PR DESCRIPTION
It's otherwise non-obvious to tell if the build failed, because build
errors end up in `build_output.txt`.