### PR TITLE
Update boundary-data-merge script to use more robust shebang

### DIFF
--- a/boundary-data-merge.py
+++ b/boundary-data-merge.py
@@ -1,4 +1,4 @@
-#!/bin/env python3
+#!/usr/bin/env python3
 
 import csv
 import json


### PR DESCRIPTION
Uses `/usr/bin/env python3` instead of `/bin/env python3`, which
means it works out of the box on macOS.